### PR TITLE
fixed ObservedObject usage

### DIFF
--- a/RelocateMe/ContentView.swift
+++ b/RelocateMe/ContentView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State var animate: Bool = false
-    @State var showSplash: Bool = true
-    @State var showImage: Bool = false
+    @State private var animate: Bool = false
+    @State private var showSplash: Bool = true
+    @State private var showImage: Bool = false
     @EnvironmentObject var envModel: EnviromentModel
     let backgroundColor = UIColor(red: 0.04, green: 0.39, blue: 0.47, alpha: 1.00)
     var body: some View {

--- a/RelocateMe/Views/About.swift
+++ b/RelocateMe/Views/About.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct About: View {
     @EnvironmentObject var envModel: EnviromentModel
-    @State var openLicense: Bool = false
+    @State private var openLicense: Bool = false
     var body: some View {
         NavigationView {
             ScrollView {

--- a/RelocateMe/Views/AddressLookup.swift
+++ b/RelocateMe/Views/AddressLookup.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct AddressLookup: View {
     @Environment(\.presentationMode) var presentationMode
-    @ObservedObject var locationSearchService = LocationSearchService()
+    @StateObject var locationSearchService = LocationSearchService()
     @Binding var selectedAddress: MKPlacemark?
     var isSelected = false
     var needCancel = false

--- a/RelocateMe/Views/EmulateRouteSheet.swift
+++ b/RelocateMe/Views/EmulateRouteSheet.swift
@@ -11,10 +11,10 @@ import SwiftUI
 
 struct EmulateRouteSheet: View {
     @EnvironmentObject var envModel: EnviromentModel
-    @ObservedObject var input = NumbersOnly()
-    @ObservedObject var routeCreator = RouteCreator()
-    @State var selectedUnit = "mph"
-    @State var buttonClicked = false
+    @StateObject var input = NumbersOnly()
+    @StateObject var routeCreator = RouteCreator()
+    @State private var selectedUnit = "mph"
+    @State private var buttonClicked = false
     private let measures = ["mph", "km/h"]
     var body: some View {
         NavigationView {

--- a/RelocateMe/Views/License.swift
+++ b/RelocateMe/Views/License.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct LicenseView: View {
-    @ObservedObject var model = Model()
+    @StateObject var model = Model()
     var body: some View {
         ScrollView {
             VStack(alignment: .center) {


### PR DESCRIPTION
Hey, so I was looking through the source here and noticed all views were using @ ObservedObject for the classes that conform to the ObservableObject protocol, however it seems @ StateObject would be the correct use here, since you are creating the objects directly in the views, so the view should know that it owns that object and should keep it alive, instead of recreating it everytime the view is discarded and redrawned, which is one of the main differences between both wrappers. Basically all the answers in this [post](https://stackoverflow.com/questions/62544115/what-is-the-difference-between-observedobject-and-stateobject-in-swiftui) explain it quite well, not just the accepted one.
I also marked @ State variables as private to add encapsulation since they shouldn't be shared across views. Sadly I can't test the code since the project isn't open source to the point it's compilable, plus I think you're using modifiers that were added after iOS 14.5, so my sdk doesn't have them, and also I'm on Linux and this is an xcode app so rip. But anyways it should still compile and there shouldn't be any visible differences.